### PR TITLE
Create utils folder inside tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ git clone https://github.com/insarlab/PyAPS.git
 git clone https://github.com/insarlab/PySolid.git
 git clone https://github.com/yunjunz/conda-envs.git
 
-mkdir ~/tools/utils
-cd ~/tools/utils
+mkdir -p ~/tools/utils; cd ~/tools/utils
 git clone https://gitlab.com/yunjunz/SSARA.git
 git clone https://github.com/yunjunz/sardem.git
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ git clone https://github.com/insarlab/PyAPS.git
 git clone https://github.com/insarlab/PySolid.git
 git clone https://github.com/yunjunz/conda-envs.git
 
+mkdir ~/tools/utils
 cd ~/tools/utils
 git clone https://gitlab.com/yunjunz/SSARA.git
 git clone https://github.com/yunjunz/sardem.git


### PR DESCRIPTION
Added a command to create `utils` folder inside `~/tools` before cloning "SSARA" and "sardem". Without this command, when you copy and paste [this block](https://github.com/yunjunz/conda-envs/blob/main/README.md#a-download-source-code), it throws a folder not found error for `cd ~/tools/utils` and clones "SSARA" and "sardem" to `~/tools` rather than `~/tools/utils`.