### PR TITLE
Added Miniforge file name for Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the Python environment with `conda/mamba`.
 
 ```bash
 mkdir -p ~/tools; cd ~/tools
-# for macOS, use Miniforge3-MacOSX-x86_64.sh, and optionally use `curl -L -O https://...` syntax to download
+# for macOS, use Miniforge3-MacOSX-x86_64.sh (intel Macs) or Miniforge3-MacOSX-arm64.sh (Apple Silicon Macs), and optionally use `curl -L -O https://...` syntax to download
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
 bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
 ~/tools/miniforge/bin/mamba init bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## conda-envs
 
-Setup InSAR data processing codes on Linux / macOS / Windows using `conda` environments.
+Set up InSAR data processing codes on Linux / macOS / Windows using `conda` environments.
 
 ### 0. (For Windows only) [Install Windows Subsystem for Linux](./docs/wsl.md)
 
@@ -10,7 +10,8 @@ Install the Python environment with `conda/mamba`.
 
 ```bash
 mkdir -p ~/tools; cd ~/tools
-# for macOS, use Miniforge3-MacOSX-x86_64.sh (intel Macs) or Miniforge3-MacOSX-arm64.sh (Apple Silicon Macs), and optionally use `curl -L -O https://...` syntax to download
+# for macOS, use Miniforge3-MacOSX-x86_64.sh (or Miniforge3-MacOSX-arm64.sh if you are using Apple Silicon Mac and all your software supports the M series chips)
+# optionally use `curl -L -O https://...` syntax to download
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
 bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
 ~/tools/miniforge/bin/mamba init bash


### PR DESCRIPTION
Added the file name (Miniforge3-MacOSX-arm64.sh) that should be used when downloading Miniforge for Apple Silicon Macs in README.md.