### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mkdir -p ~/tools; cd ~/tools
 # for macOS, use Miniforge3-MacOSX-x86_64.sh, and optionally use `curl -L -O https://...` syntax to download
 wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
 bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
-~/tools/miniforge/bin/mamba init bash
+~/tools/miniforge/bin/mamba shell
 ```
 
 Close and restart the shell for changes to take effect. Then install the following utilities:


### PR DESCRIPTION
the command: ./miniforge/bin/mamba init bash
generates this error: The following arguments were not expected: init bash Run with --help for more information.

To fix it you just need to replace init bash with shell
 
